### PR TITLE
New processor for easier OverlayTiming configuration

### DIFF
--- a/include/OverlayTiming.h
+++ b/include/OverlayTiming.h
@@ -9,6 +9,13 @@
 #include <cmath>
 #include <limits>
 
+namespace EVENT{
+  class SimCalorimeterHit;
+  class LCRunHeader;
+  class LCEvent;
+  class LCCollection;
+}
+
 namespace overlay {
 
   /** OverlayTiming processor for overlaying background to each bunch crossing of a bunch train.
@@ -50,6 +57,7 @@ namespace overlay {
     virtual marlin::Processor*  newProcessor();
 
     OverlayTiming();
+    OverlayTiming(std::string const& name);
     OverlayTiming( OverlayTiming const&) = delete;
     OverlayTiming& operator=(OverlayTiming const&) = delete;
 
@@ -68,7 +76,7 @@ namespace overlay {
   protected:
     float time_of_flight(float x, float y, float z) const;
 
-    void define_time_windows(const std::string &Collection_name);
+    virtual void define_time_windows(const std::string &Collection_name);
 
     void crop_collection(EVENT::LCCollection *collection);
 
@@ -136,14 +144,14 @@ namespace overlay {
 
   //------------------------------------------------------------------------------------------------------------------------------------------
 
-  marlin::Processor *OverlayTiming::newProcessor()
+  inline marlin::Processor *OverlayTiming::newProcessor()
   {
     return new OverlayTiming;
   }
 
   //------------------------------------------------------------------------------------------------------------------------------------------
 
-  const std::string &OverlayTiming::name() const
+  inline const std::string &OverlayTiming::name() const
   {
     return marlin::Processor::name();
   }

--- a/include/OverlayTiming.h
+++ b/include/OverlayTiming.h
@@ -82,7 +82,7 @@ namespace overlay {
 
     void merge_collections(EVENT::LCCollection *source_collection, EVENT::LCCollection *dest_collection, float time_offset);
 
-    long long cellID2long(int id0, int id1) const;
+    unsigned long long cellID2long(unsigned int id0, unsigned int id1) const;
 
     float _T_diff = 0.5;
     int _nBunchTrain = 1;
@@ -137,7 +137,7 @@ namespace overlay {
     float _tpcVdrift_mm_ns = 5.0e-2 ;
     bool _randomBX = false, _Poisson = false;
 
-    typedef std::map<long long, EVENT::SimCalorimeterHit*> DestMap;
+    typedef std::map<unsigned long long, EVENT::SimCalorimeterHit*> DestMap;
     typedef std::map<std::string, DestMap> CollDestMap;
     CollDestMap collDestMap{};
   };
@@ -167,9 +167,10 @@ namespace overlay {
 
   //------------------------------------------------------------------------------------------------------------------------------------------
 
-  inline long long OverlayTiming::cellID2long(int id0, int id1) const
+  inline unsigned long long OverlayTiming::cellID2long(unsigned int id0, unsigned int id1) const
   {
-    return ((long long) id0 << 32) | id1;
+    const unsigned long long newID = ((unsigned long long)(id0) << sizeof(unsigned int)*8 | (unsigned long long)id1);
+    return newID;
   }
 
 } // namespace

--- a/include/OverlayTimingGeneric.h
+++ b/include/OverlayTimingGeneric.h
@@ -1,0 +1,52 @@
+ #ifndef OverlayTimingGeneric_h
+#define OverlayTimingGeneric_h 1
+
+#include "OverlayTiming.h"
+
+#include "marlin/Processor.h"
+#include "marlin/EventModifier.h"
+
+#include "lcio.h"
+
+#include <cmath>
+#include <limits>
+
+namespace EVENT{
+  class SimCalorimeterHit;
+  class LCRunHeader;
+  class LCEvent;
+  class LCCollection;
+}
+
+class OverlayTimingGeneric : public overlay::OverlayTiming {
+public:
+  virtual marlin::Processor* newProcessor();
+  virtual std::string const& name() const;
+
+  OverlayTimingGeneric();
+  OverlayTimingGeneric( OverlayTimingGeneric const&) = delete;
+  OverlayTimingGeneric& operator=(OverlayTimingGeneric const&) = delete;
+
+  virtual void init();
+
+protected:
+
+  virtual void define_time_windows(const std::string &collectionName);
+  std::vector<std::string> _collectionTimesVec{"BeamCalCollection", "10"};
+  std::map< std::string, float > _collectionIntegrationTimes{};
+
+};
+
+inline marlin::Processor *OverlayTimingGeneric::newProcessor()
+{
+  return new OverlayTimingGeneric();
+}
+
+//------------------------------------------------------------------------------------------------------------------------------------------
+
+inline const std::string &OverlayTimingGeneric::name() const
+{
+  return marlin::Processor::name();
+}
+
+#endif

--- a/src/OverlayTiming.cc
+++ b/src/OverlayTiming.cc
@@ -24,6 +24,9 @@ namespace overlay {
 
   OverlayTiming aOverlayTiming;
 
+  OverlayTiming::OverlayTiming( std::string const& name) : Processor(name)
+  {}
+
   OverlayTiming::OverlayTiming() : Processor("OverlayTiming")
   {
     // modify processor description

--- a/src/OverlayTiming.cc
+++ b/src/OverlayTiming.cc
@@ -676,9 +676,9 @@ namespace overlay {
                 SimCalorimeterHit *CalorimeterHit = dynamic_cast<SimCalorimeterHit*>(source_collection->getElementAt(k));
                 const float _time_of_flight = time_of_flight(CalorimeterHit->getPosition()[0], CalorimeterHit->getPosition()[1], CalorimeterHit->getPosition()[2]);
 
-                //check whether there is already a hit at this position 
-                DestMap::const_iterator destMapIt =  collDestMap[currentDest].find(cellID2long(CalorimeterHit->getCellID0(), CalorimeterHit->getCellID1()));
-
+                //check whether there is already a hit at this position
+                const unsigned long long lookfor = cellID2long(CalorimeterHit->getCellID0(), CalorimeterHit->getCellID1());
+                DestMap::const_iterator destMapIt = collDestMap[currentDest].find(lookfor);
                 if (destMapIt == collDestMap[currentDest].end())
 		  {
                     // There is no Hit at this position -- the new hit can be added, if it is not outside the window
@@ -732,6 +732,12 @@ namespace overlay {
 		    
 		    
 		      //		      std::exit(1);
+		      streamlog_out(ERROR) << "ID1New  " << cellID2long(newCalorimeterHit->getCellID0(),
+                                                                        newCalorimeterHit->getCellID1())
+                                           << "   Old  " << cellID2long(CalorimeterHit->getCellID0(),
+                                                                        CalorimeterHit->getCellID1())
+                                           << std::endl;
+
 		    }
 		    for (int j = 0; j < CalorimeterHit->getNMCContributions(); ++j)
 		      {

--- a/src/OverlayTiming.cc
+++ b/src/OverlayTiming.cc
@@ -60,7 +60,7 @@ namespace overlay {
 				float(5.0e-2) );
 
     registerProcessorParameter( "RandomBx", 
-				"Place the physics event at an random position in the train -- overrides PhysicsBX",
+				"Place the physics event at an random position in the train: overrides PhysicsBX",
 				_randomBX,
 				bool(false) );
 

--- a/src/OverlayTiming.cc
+++ b/src/OverlayTiming.cc
@@ -387,6 +387,11 @@ namespace overlay {
                     LCCollection *Collection_in_overlay_Evt = overlay_Evt->getCollection(Collection_name);
                     LCCollection *Collection_in_Physics_Evt = 0;
 
+                    //Skip the MCParticle collection
+                    if( Collection_name == _mcParticleCollectionName ) {
+                      continue;
+                    }
+
                     define_time_windows(Collection_name);
 
                     //the event can only make contributions to the readout, if the bx does not happen after the integration time stopped.

--- a/src/OverlayTimingGeneric.cc
+++ b/src/OverlayTimingGeneric.cc
@@ -1,0 +1,130 @@
+#include "OverlayTimingGeneric.h"
+
+#include "CLHEP/Random/RandFlat.h"
+#include "CLHEP/Random/RandPoisson.h"
+
+OverlayTimingGeneric aOverlayTimingGeneric;
+
+OverlayTimingGeneric::OverlayTimingGeneric(): OverlayTiming("OverlayTimingGeneric")
+{
+  // modify processor description
+  _description = "Processor to overlay events from the background taking the timing of the subdetectors into account";
+
+  StringVec files;
+
+  registerProcessorParameter("Delta_t",
+                             "Time difference between bunches in the bunch train in ns",
+                             _T_diff,
+                             float(0.5));
+
+  registerProcessorParameter("NBunchtrain",
+                             "Number of bunches in a bunch train",
+                             _nBunchTrain,
+                             int(1));
+
+  registerProcessorParameter( "BackgroundFileNames",
+                              "Name of the lcio input file(s) with background - assume one file per bunch crossing.",
+                              _inputFileNames,
+                              files);
+
+  registerProcessorParameter("PhysicsBX",
+                             "Number of the Bunch crossing of the physics event",
+                             _BX_phys,
+                             int(1));
+
+  registerProcessorParameter( "TPCDriftvelocity",
+                              "[mm/ns] (float) - default 5.0e-2 (5cm/us)",
+                              _tpcVdrift_mm_ns,
+                              float(5.0e-2) );
+
+  registerProcessorParameter( "RandomBx",
+                              "Place the physics event at an random position in the train: overrides PhysicsBX",
+                              _randomBX,
+                              bool(false) );
+
+  registerProcessorParameter( "NumberBackground",
+                              "Number of Background events to overlay - either fixed or Poisson mean",
+                              _NOverlay,
+                              float(1) );
+
+  registerProcessorParameter( "Poisson_random_NOverlay",
+                              "Draw random number of Events to overlay from Poisson distribution with  mean value NumberBackground",
+                              _Poisson,
+                              bool(false) );
+
+  registerProcessorParameter( "RandomSeed",
+                              "random seed - default 42",
+                              _ranSeed,
+                              int(42) );
+
+  registerProcessorParameter("MCParticleCollectionName",
+                             "The MC Particle Collection Name",
+                             _mcParticleCollectionName,
+                             std::string("MCParticle"));
+
+  registerProcessorParameter("MCPhysicsParticleCollectionName",
+                             "The output MC Particle Collection Name for the physics event" ,
+                             _mcPhysicsParticleCollectionName,
+                             std::string("MCPhysicsParticles"));
+
+  //Collections with Integration Times
+  registerProcessorParameter("Collection_IntegrationTimes",
+                             "Integration times for the Collections",
+                             _collectionTimesVec,
+                             _collectionTimesVec);
+}
+
+void OverlayTimingGeneric::init()
+{
+
+  printParameters();
+
+  overlay_Eventfile_reader = LCFactory::getInstance()->createLCReader();
+
+  streamlog_out(WARNING) << "Attention! There are " << _inputFileNames.size()
+                         << " files in the list of background files to overlay. Make sure that the total number of background events is sufficiently large for your needs!!"
+                         << std::endl;
+
+  CLHEP::HepRandom::setTheSeed(_ranSeed);
+
+  _nRun = 0;
+  _nEvt = 0;
+
+
+  if( _collectionTimesVec.size() % 2 != 0 ){
+    std::runtime_error( "bad entries for parameter 'Collection_Integration Times! Need pairs of collection and integration times");
+  }
+
+  // parse the collectionTimesVec vector to get the collections and integration times
+  for (size_t i = 0; i < _collectionTimesVec.size(); i+=2 ) {
+    _collectionIntegrationTimes[ _collectionTimesVec[i] ] = std::atof( _collectionTimesVec[i+1].c_str() );
+  }
+
+  for (auto const& entry : _collectionIntegrationTimes) {
+    streamlog_out(MESSAGE) << entry.first << ": " << entry.second  << std::endl;
+  }
+
+
+}
+
+//------------------------------------------------------------------------------------------------------------------------------------------
+
+void OverlayTimingGeneric::define_time_windows( std::string const& collectionName ) {
+
+  this_start= -0.25; //the integration time shall start shortly before the BX
+  //with the physics event to avoid timing problems the
+  //value of -0.25 is a arbitrary number for the moment
+  //but should be sufficient -- corresponds to 7.5cm of
+  //flight at c
+
+  this_stop= 0.0;
+  TPC_hits = false;
+
+  auto iter = _collectionIntegrationTimes.find( collectionName );
+  if ( iter != _collectionIntegrationTimes.end() ) {
+    this_stop = iter->second;
+  } else {
+    throw std::runtime_error( "Cannot find integration time for collection " + collectionName );
+  }
+
+}


### PR DESCRIPTION
~If someone has a better name...~
Named now `OverlayTimingGeneric`

BEGINRELEASENOTES
- New processor OverlayTimingGeneric: Same as OverlayTiming, but easier configuration of the collections to be merged. No more hard coding of parameters for each parameter name. 
Shares most of the code and parameters with OverlayTiming
To configure collections and integration times:
  ```
   <parameter name="Collection_IntegrationTimes" type="StringVec" >
      VertexBarrelCollection        10
      VertexEndcapCollection        10

      InnerTrackerBarrelCollection  10
      InnerTrackerEndcapCollection  10

      OuterTrackerBarrelCollection  10
      OuterTrackerEndcapCollection  10

      ECalBarrelCollection          10
      ECalEndcapCollection          10
      ECalPlugCollection            10

      HCalBarrelCollection          10
      HCalEndcapCollection          10
      HCalRingCollection            10

      YokeBarrelCollection          10
      YokeEndcapCollection          10

      LumiCalCollection             10
      BeamCalCollection             10
    </parameter>
  ```
- Fix bug in OverlayTiming::cellID2long which returned the same `long long` for different cellID pairs

ENDRELEASENOTES