### PR TITLE
OverlayTiming: cleanup lcreader at the end

### DIFF
--- a/src/OverlayTiming.cc
+++ b/src/OverlayTiming.cc
@@ -772,6 +772,8 @@ namespace overlay {
 
   void OverlayTiming::end()
   {
+    delete overlay_Eventfile_reader;
+    overlay_Eventfile_reader = nullptr;
   }
 
 


### PR DESCRIPTION

BEGINRELEASENOTES
- OverlayTiming[Generic]: clean the LCReader instance at the end

ENDRELEASENOTES