### PR TITLE
OverlayTiming[Generic]: better use of events in files

### DIFF
--- a/include/OverlayTiming.h
+++ b/include/OverlayTiming.h
@@ -124,6 +124,7 @@ namespace overlay {
     float _TPCSpacePoint_int = 10;
 
     IO::LCReader* overlay_Eventfile_reader = NULL;
+    LCEvent* overlay_Evt = nullptr;
 
     float this_start = -0.25;
     float this_stop = std::numeric_limits<float>::max();

--- a/include/OverlayTiming.h
+++ b/include/OverlayTiming.h
@@ -125,10 +125,13 @@ namespace overlay {
 
     IO::LCReader* overlay_Eventfile_reader = NULL;
     LCEvent* overlay_Evt = nullptr;
+    int m_eventCounter = 0;
+    int m_currentFileIndex = 0;
+    int m_startWithBackgroundFile = -1;
+    int m_startWithBackgroundEvent = -1;
 
     float this_start = -0.25;
     float this_stop = std::numeric_limits<float>::max();
-    int _ranSeed = 42;
 
     std::string _mcParticleCollectionName = "";
     std::string _mcPhysicsParticleCollectionName = "";

--- a/src/OverlayTiming.cc
+++ b/src/OverlayTiming.cc
@@ -288,7 +288,7 @@ namespace overlay {
 
     int random_file = int(CLHEP::RandFlat::shoot(_inputFileNames.size() - 1));
     //Make sure we have filenames to open and that we really want to overlay something
-    if ((random_file > -1) && (_NOverlay > 0.))
+    if ((random_file > -1) && (_NOverlay > 0.) && overlay_Evt == nullptr)
       {
         overlay_Eventfile_reader->open(_inputFileNames.at(random_file));
         streamlog_out(DEBUG) << "Open background file: " << _inputFileNames.at(random_file) << std::endl;
@@ -349,7 +349,7 @@ namespace overlay {
 
             for (int k = 0; k < NOverlay_to_this_BX; ++k)
 	      {
-                LCEvent *overlay_Evt = overlay_Eventfile_reader->readNextEvent(LCIO::UPDATE);
+                overlay_Evt = overlay_Eventfile_reader->readNextEvent(LCIO::UPDATE);
 
                 //if there are no events left in the actual file, open the next one.
                 if (overlay_Evt == 0)
@@ -458,7 +458,6 @@ namespace overlay {
 		  }
 	      }
 	  }
-        overlay_Eventfile_reader->close();
       } //If we have any files, and more than 0 events to overlay end 
 
     delete permutation;

--- a/src/OverlayTiming.cc
+++ b/src/OverlayTiming.cc
@@ -276,7 +276,7 @@ namespace overlay {
         streamlog_out(DEBUG) << "Physics Event was placed in the " << _BX_phys << " bunch crossing!" << std::endl;
       }
 
-    //define a permutation for the events to overlay -- the physics event is [er definition at position 0
+    //define a permutation for the events to overlay -- the physics event is per definition at position 0
     std::vector<int> *permutation = new std::vector<int>;
 
     for (int i = -(_BX_phys - 1); i < _nBunchTrain - (_BX_phys - 1); ++i)

--- a/src/OverlayTiming.cc
+++ b/src/OverlayTiming.cc
@@ -272,7 +272,7 @@ namespace overlay {
 
     if (_randomBX) 
       {
-        _BX_phys = int(CLHEP::RandFlat::shoot(_nBunchTrain));
+        _BX_phys = CLHEP::RandFlat::shootInt(_nBunchTrain);
         streamlog_out(DEBUG) << "Physics Event was placed in the " << _BX_phys << " bunch crossing!" << std::endl;
       }
 
@@ -284,9 +284,9 @@ namespace overlay {
         permutation->push_back(i);
       }
 
-    random_shuffle(permutation->begin(), permutation->end());
+    random_shuffle(permutation->begin(), permutation->end(), [](int n){ return CLHEP::RandFlat::shootInt(n); } );
 
-    int random_file = int(CLHEP::RandFlat::shoot(_inputFileNames.size() - 1));
+    int random_file = CLHEP::RandFlat::shootInt(_inputFileNames.size());
     //Make sure we have filenames to open and that we really want to overlay something
     if ((random_file > -1) && (_NOverlay > 0.) && overlay_Evt == nullptr)
       {
@@ -355,7 +355,7 @@ namespace overlay {
                 if (overlay_Evt == 0)
 		  {
                     overlay_Eventfile_reader->close();
-                    random_file = int(CLHEP::RandFlat::shoot(_inputFileNames.size()-1));
+                    random_file = CLHEP::RandFlat::shootInt(_inputFileNames.size());
                     overlay_Eventfile_reader->open (_inputFileNames.at(random_file));
                     overlay_Evt = overlay_Eventfile_reader->readNextEvent(LCIO::UPDATE);
                     streamlog_out(DEBUG) << "Open background file: " << _inputFileNames.at(random_file) << std::endl;

--- a/src/OverlayTiming.cc
+++ b/src/OverlayTiming.cc
@@ -291,7 +291,7 @@ namespace overlay {
     if ((random_file > -1) && (_NOverlay > 0.) && overlay_Evt == nullptr)
       {
         overlay_Eventfile_reader->open(_inputFileNames.at(random_file));
-        streamlog_out(DEBUG) << "Open background file: " << _inputFileNames.at(random_file) << std::endl;
+        streamlog_out(MESSAGE) << "Open background file: " << _inputFileNames.at(random_file) << std::endl;
       }
 
     //We have the physics event in evt. Now we merge the new overlay events with it.
@@ -358,7 +358,7 @@ namespace overlay {
                     random_file = CLHEP::RandFlat::shootInt(_inputFileNames.size());
                     overlay_Eventfile_reader->open (_inputFileNames.at(random_file));
                     overlay_Evt = overlay_Eventfile_reader->readNextEvent(LCIO::UPDATE);
-                    streamlog_out(DEBUG) << "Open background file: " << _inputFileNames.at(random_file) << std::endl;
+                    streamlog_out(MESSAGE) << "Open background file: " << _inputFileNames.at(random_file) << std::endl;
 		  }
 
                 // the overlay_Event is now open, start to merge its collections with the ones of the accumulated overlay events collections

--- a/src/OverlayTiming.cc
+++ b/src/OverlayTiming.cc
@@ -320,7 +320,7 @@ namespace overlay {
                 colPhysicsMc->setSubset(true);
                 for (int k = 0; k < number_of_elements; ++k)
 		  {
-                    MCParticle *pMc = dynamic_cast<MCParticle*>(Collection_in_Physics_Evt->getElementAt(k));
+                    MCParticle *pMc = static_cast<MCParticle*>(Collection_in_Physics_Evt->getElementAt(k));
                     colPhysicsMc->addElement(pMc);
 		  }
                 evt->addCollection(colPhysicsMc,_mcPhysicsParticleCollectionName.c_str());
@@ -544,7 +544,7 @@ namespace overlay {
 	  {
             for (int k = number_of_elements - 1; k >= 0; --k)
 	      {
-                SimTrackerHit *TrackerHit = dynamic_cast<SimTrackerHit*>(collection->getElementAt(k));
+                SimTrackerHit *TrackerHit = static_cast<SimTrackerHit*>(collection->getElementAt(k));
                 const float _time_of_flight = time_of_flight(TrackerHit->getPosition()[0], TrackerHit->getPosition()[1], TrackerHit->getPosition()[2]);
                 if (!((TrackerHit->getTime() > (this_start + _time_of_flight)) && (TrackerHit->getTime() < (this_stop + _time_of_flight))))
 		  {
@@ -558,7 +558,7 @@ namespace overlay {
             //we count from top to bottom, in order not to get confused when removing and adding elements!
             for (int i =  number_of_elements - 1; i >= 0; --i) 
 	      {
-                SimCalorimeterHit *CalorimeterHit = dynamic_cast<SimCalorimeterHit*>(collection->getElementAt(i));
+                SimCalorimeterHit *CalorimeterHit = static_cast<SimCalorimeterHit*>(collection->getElementAt(i));
                 int not_within_time_window = 0;
 
                 // check whether all entries are within the time window
@@ -628,7 +628,7 @@ namespace overlay {
 	  {
             for (int i = number_of_elements - 1; i >= 0; --i)
 	      {
-                MCParticleImpl *MC_Part = dynamic_cast<MCParticleImpl*>(source_collection->getElementAt(i));
+                MCParticleImpl *MC_Part = static_cast<MCParticleImpl*>(source_collection->getElementAt(i));
                 MC_Part->setTime(MC_Part->getTime() + time_offset);
                 dest_collection->addElement(MC_Part);
                 source_collection->removeElementAt(i);
@@ -638,7 +638,7 @@ namespace overlay {
 	  {
             for (int k = number_of_elements - 1; k >= 0; --k)
 	      {
-                SimTrackerHitImpl *TrackerHit = dynamic_cast<SimTrackerHitImpl*>(source_collection->getElementAt(k));
+                SimTrackerHitImpl *TrackerHit = static_cast<SimTrackerHitImpl*>(source_collection->getElementAt(k));
                 const float _time_of_flight = time_of_flight(TrackerHit->getPosition()[0], TrackerHit->getPosition()[1], TrackerHit->getPosition()[2]);
 
                 if (((TrackerHit->getTime() + time_offset) > (this_start + _time_of_flight)) && ((TrackerHit->getTime() + time_offset) < (this_stop + _time_of_flight)))
@@ -653,7 +653,7 @@ namespace overlay {
 	  {
             for (int k = number_of_elements - 1; k >= 0; --k) 
 	      {
-                SimTrackerHitImpl *TrackerHit = dynamic_cast<SimTrackerHitImpl*>(source_collection->getElementAt (k));
+                SimTrackerHitImpl *TrackerHit = static_cast<SimTrackerHitImpl*>(source_collection->getElementAt (k));
                 const float _time_of_flight = time_of_flight(TrackerHit->getPosition()[0], TrackerHit->getPosition()[1], TrackerHit->getPosition()[2]);
 
                 if (((TrackerHit->getTime() + time_offset) > (this_start + _time_of_flight)) && ((TrackerHit->getTime() + time_offset) < (this_stop + _time_of_flight)))
@@ -679,7 +679,7 @@ namespace overlay {
             // create a map of dest Collection
             for (int k =  number_of_elements - 1; k >= 0; --k) 
 	      {
-                SimCalorimeterHit *CalorimeterHit = dynamic_cast<SimCalorimeterHit*>(source_collection->getElementAt(k));
+                SimCalorimeterHit *CalorimeterHit = static_cast<SimCalorimeterHit*>(source_collection->getElementAt(k));
                 const float _time_of_flight = time_of_flight(CalorimeterHit->getPosition()[0], CalorimeterHit->getPosition()[1], CalorimeterHit->getPosition()[2]);
 
                 //check whether there is already a hit at this position
@@ -716,7 +716,7 @@ namespace overlay {
                 else
 		  {
 		    // there is already a hit at this position.... 
-		    SimCalorimeterHitImpl *newCalorimeterHit = dynamic_cast <SimCalorimeterHitImpl*>(destMapIt->second);
+		    SimCalorimeterHitImpl *newCalorimeterHit = static_cast <SimCalorimeterHitImpl*>(destMapIt->second);
 		    ++mergedN;
 		    if((newCalorimeterHit->getPosition()[0]-CalorimeterHit->getPosition()[0])*
 		       (newCalorimeterHit->getPosition()[0]-CalorimeterHit->getPosition()[0])+

--- a/src/OverlayTimingGeneric.cc
+++ b/src/OverlayTimingGeneric.cc
@@ -70,6 +70,17 @@ OverlayTimingGeneric::OverlayTimingGeneric(): OverlayTiming("OverlayTimingGeneri
                              "Integration times for the Collections",
                              _collectionTimesVec,
                              _collectionTimesVec);
+
+    registerOptionalParameter("StartBackgroundFileIndex",
+			       "Which background file to startWith",
+			       m_startWithBackgroundFile,
+			       m_startWithBackgroundFile);
+
+    registerOptionalParameter("StartBackgroundEventIndex",
+			       "Which background event to startWith",
+			       m_startWithBackgroundEvent,
+			       m_startWithBackgroundEvent);
+
 }
 
 void OverlayTimingGeneric::init()


### PR DESCRIPTION
BEGINRELEASENOTES
- OverlayTiming[Generic]: exhaust all events in a file instead of opening a file for each event. Should be reproducible for when not skipping events.
- OverlayTiming[Generic]: add parameters that allow setting the initial state also after skipping events.
ENDRELEASENOTES