### PR TITLE
OverlayTiming[Generic]: optionally prevent re-use of background files 

### DIFF
--- a/include/OverlayTiming.h
+++ b/include/OverlayTiming.h
@@ -129,6 +129,7 @@ namespace overlay {
     int m_currentFileIndex = 0;
     int m_startWithBackgroundFile = -1;
     int m_startWithBackgroundEvent = -1;
+    bool m_allowReusingBackgroundFiles = true;
 
     float this_start = -0.25;
     float this_stop = std::numeric_limits<float>::max();

--- a/src/OverlayTimingGeneric.cc
+++ b/src/OverlayTimingGeneric.cc
@@ -71,6 +71,11 @@ OverlayTimingGeneric::OverlayTimingGeneric(): OverlayTiming("OverlayTimingGeneri
                              _collectionTimesVec,
                              _collectionTimesVec);
 
+  registerProcessorParameter("AllowReusingBackgroundFiles",
+                             "If true the same background file can be used for the same event",
+                             m_allowReusingBackgroundFiles,
+                             m_allowReusingBackgroundFiles);
+
     registerOptionalParameter("StartBackgroundFileIndex",
 			       "Which background file to startWith",
 			       m_startWithBackgroundFile,


### PR DESCRIPTION

BEGINRELEASENOTES
- OverlayTiming[Generic]: optionally prevent re-use of background files
   * keep track of used files and only use files that haven't been used before
   * add parameter AllowReusingBackgroundFiles (default true for backward compatibility)

ENDRELEASENOTES