### PR TITLE
Overlay process: a complete re-write

### DIFF
--- a/include/Overlay.h
+++ b/include/Overlay.h
@@ -7,26 +7,81 @@
 #include <string>
 
 
-namespace overlay{
+namespace overlay {
+  
+  /**
+   *  @brief  LCFileHandler class
+   */
+  class LCFileHandler {
+  public:
+    // Default constructors
+    LCFileHandler() = default;
+    LCFileHandler(const LCFileHandler&) = default;
+    LCFileHandler& operator =(const LCFileHandler&) = default;
+
+    /**
+     *  @brief  Set the LCIO file name
+     *  
+     *  @param  fname the name of the LCIO file
+     */
+    void setFileName(const std::string& fname);
+    
+    /**
+     *  @brief  Get the number of events available in the file
+     */
+    unsigned int getNumberOfEvents() const;
+    
+    /**
+     *  @brief  Get the event number at the specified index (look in the event map)
+     *  
+     *  @param  index the nth event to get
+     */
+    unsigned int getEventNumber(unsigned int index) const;
+    
+    /**
+     *  @brief  Get the run number at the specified index (look in the event map)
+     *  
+     *  @param  index the nth run to get
+     */
+    unsigned int getRunNumber(unsigned int index) const;
+    
+    /**
+     *  @brief  Read the specified event, by run and event number
+     *  
+     *  @param  runNumber the run number of the event to read
+     *  @param  eventNumber the event number of the event to read
+     */
+    EVENT::LCEvent* readEvent(int runNumber, int eventNumber);
+    
+  private:
+    /**
+     *  @brief  Proxy method to open the LCIO file
+     */
+    void openFile() const;
+
+  private:
+    mutable std::shared_ptr<IO::LCReader>          _lcReader{}; ///< The LCIO file reader
+    mutable EVENT::IntVec                          _eventMap{}; ///< The run and event number 
+    std::string                                    _fileName{}; ///< The LCIO file name    
+  };
+  
+  typedef std::vector<LCFileHandler> LCFileHandlerList;
 
   /** Overlay processor allows to overlay an event with background events from 
    *  additional LCIO files based on different criteria.
    *
    *  A typical use case would be the overlay of gamma gamma -> hadrons background events
    *  with a number drawn from a poissonian distribution with a given mean 'expBG' (NumberOverlayEvents=0).
-   *  Best to specfiy only one input file as then direct access in LCIO is used.
    *
    *  See Merger.cc for the collection types that can be merged.
    * 
    * @author N. Chiapolini, DESY
    * @author F. Gaede, DESY
+   * @author R. Ete, DESY
    * @version $Id$
    * 
    * @param InputFileNames (StringVec) The names (with absolute or relative pathes) of the files from which the background should be read.
    *                                   Multiple files can be given by a white spaces separated list or by setting this parameter multiple times. 
-   *                                   If the end of the last file is reached, before all events have been processed, a warning will be printed 
-   *                                   and reading restarted with the first file.
-   *                                   NB: if only one file is given direct access is used - this is much faster (and thus preferred)
    *                              
    * @param CollectionMap (StringVec)  Pairs of collection names. The input collection (given first) will be merged into the output collection.
    *                                   If the output collection does not exist, it will be created. It is recommended to set this parameter once
@@ -36,81 +91,80 @@ namespace overlay{
    *
    * @param expBG (double)             If this value is set, a random number of background will be added to each physics event. 
    *                                   The Random numbers will be thrown according to a Poisson distribution with this expectation value.
-   *                                   If set, NumberOverlayEvents will be added to the random number.
-   * @param runOverlay (bool)          If true, NumberOverlayEvents and expBG will be ignored. Instead one run of background events will be added to each physics event.
-   *
-   * @param NSkipEventsRandom          Maximum number of events to skip between overlayd events (choosen from flat intervall [0,NSkipEventsRandom] )
-   *                                   used if more than one inout file given and skipNEvent is used                                       
+   *                                   If set, NumberOverlayEvents will be added to the random number.                                  
    */
-
-  class Overlay : public marlin::Processor, public marlin::EventModifier {
-  
-  public:
-  
-    virtual marlin::Processor*  newProcessor() { return new Overlay ; }
-  
-  
-    Overlay() ;
+  class Overlay final : public marlin::Processor, public marlin::EventModifier {
+    // Deleted member functions : no copy
     Overlay( Overlay const&) = delete;
     Overlay& operator=(Overlay const&) = delete;
+  public:
+    /**
+     *  @brief  Constructor
+     */
+    Overlay() ;
+        
+    /**
+     *  @brief  Factory method to create a new processor
+     */
+    marlin::Processor* newProcessor() override { return new Overlay() ; }
 
-    virtual const std::string & name() const { return Processor::name() ; }
-  
-    virtual void modifyEvent( EVENT::LCEvent * evt ) ; 
+    /**
+     *  @brief  Modify the event
+     *  
+     *  @param  evt the event to modify
+     */
+    void modifyEvent( EVENT::LCEvent * evt ) override ; 
 
+    /**
+     *  @brief  Get the processor name. Need to override it because of EventModifier inheritance
+     */
+    const std::string & name() const override ;
 
-    /** Called at the begin of the job before anything is read.
-     * Use to initialize the processor, e.g. book histograms.
+    /** 
+     *  @brief Called at the begin of the job before anything is read.
+     *         Use to initialize the processor, e.g. book histograms.
      */
-    virtual void init() ;
+    void init() override ;
   
-    /** Called for every run.
+    /** 
+     *  @brief  Called for every run.
+     *
+     *  @param  run the run header to process 
      */
-    virtual void processRunHeader( LCRunHeader* run ) ;
+    void processRunHeader( LCRunHeader* run ) override ;  
   
-    /** Called for every event - the working horse.
+    /** 
+     *  @brief  Called after data processing for clean up.
      */
-    //  virtual void processEvent( EVENT::LCEvent * evt ) ; 
-  
-  
-    virtual void check( EVENT::LCEvent * evt ) ; 
-  
-  
-    /** Called after data processing for clean up.
-     */
-    virtual void end() ;
-  
+    void end() override ;
   
   protected:
-
-
-    /** Helper method.
+    /**
+     *  @brief  Get the total number of event available in the overlay input files
      */
-    LCEvent* readNextEvent( ) ;
+    unsigned int getNAvailableEvents() const; 
 
-    /** Input file names.
+    /** 
+     *  @brief  Helper method to randomly pick an event from available overlay input files 
      */
-    StringVec _fileNames{};
-    int       _numOverlay = 0;
-    double    _expBG = 1;
-    bool      _runOverlay = false;
-    int       _nSkipEventsRandom = 0 ;
+    LCEvent* readNextEvent() ;
 
-    StringVec _colVec{};
-    std::map<std::string, std::string> _colMap{};
-
-    IO::LCReader* _lcReader = NULL;
-    EVENT::LCEvent* _overlayEvent = NULL;
-
-    int _activeRunNumber = 0;
-    int _nRun = 0;
-    int _nEvt = 0;
-    int _nOverlayEvt = 0;
-    IntVec _events{};
+  private:
+    // processor parameters
+    EVENT::StringVec                      _fileNames {} ;             ///< The overlay input file names
+    EVENT::StringVec                      _overlayCollections {} ;    ///< The list of pair of collections to overlay (see class description)
+    int                                   _numOverlay {0} ;           ///< The additional number of events to overlay
+    double                                _expBG {1} ;                ///< The mean value of the poisson distribution when randomly picking events
+    
+    // internal members
+    unsigned int                          _nAvailableEvents {0} ;     ///< The total number of available overlay events from input files
+    std::map<std::string, std::string>    _overlayCollectionMap {} ;  ///< The map of collections to overlay, built from _overlayCollections
+    int                                   _nRun {0} ;                 ///< The total number of processed runs
+    int                                   _nEvt {0} ;                 ///< The total number of processed events
+    int                                   _nTotalOverlayEvents {0} ;  ///< The total number of overlaid events when processor ends
+    LCFileHandlerList                     _lcFileHandlerList {} ;     ///< The list of file handler to manage overlay input files (see LCFileHandler class)
   } ;
 
 }
+
 #endif
-
-
-

--- a/src/Overlay.cc
+++ b/src/Overlay.cc
@@ -198,6 +198,7 @@ namespace overlay {
 			    << std::endl;
   
     int nOverlaidEvents(0);
+    EVENT::FloatVec overlaidEventIDs, overlaidRunIDs;
     
     for(unsigned int i=0 ; i < nEventsToOverlay ; i++ ) {
 
@@ -207,6 +208,9 @@ namespace overlay {
 	       streamlog_out( ERROR ) << "loop: " << i << " ++++++++++ Nothing to overlay +++++++++++ \n " ;
 	       continue ;
       } 
+      
+      overlaidEventIDs.push_back( overlayEvent->getEventNumber() );
+      overlaidRunIDs.push_back( overlayEvent->getRunNumber() );
       
       ++nOverlaidEvents ;
 
@@ -233,6 +237,10 @@ namespace overlay {
     // Write info to event parameters
     std::string paramName = "Overlay." + this->name() + ".nEvents";
     evt->parameters().setValue(paramName, nOverlaidEvents);
+    paramName = "Overlay." + this->name() + ".eventIDs";
+    evt->parameters().setValues(paramName, overlaidEventIDs);
+    paramName = "Overlay." + this->name() + ".runIDs";
+    evt->parameters().setValues(paramName, overlaidRunIDs);
     
     int totalOverlay = evt->parameters().getIntVal("Overlay.nTotalEvents"); // returns 0 if the key doesn't exists
     totalOverlay += nOverlaidEvents;


### PR DESCRIPTION
BEGINRELEASENOTES
- Complete re-write of Overlay processor
   - Removed processor parameters (RunOverlay and NSkipEventsRandom)
   - Overlay of multiple files work as for a single file
   - If no collection specified in config, overlay all present collections 
   - Write in the event parameters: 
      - Overlaid run and event numbers
      - Number of overlaid events per processor and from all processors
   - Code documented and c++11 styled
   - Methods and class members cleaned-up

ENDRELEASENOTES