### PR TITLE
make compatible w/ c++17

### DIFF
--- a/src/OverlayTiming.cc
+++ b/src/OverlayTiming.cc
@@ -18,9 +18,9 @@
 #include <marlin/Global.h>
 #include <marlin/ProcessorEventSeeder.h>
 
-#include <random>
 #include <algorithm>
 #include <limits>
+#include <random>
 #include <set>
 
 using namespace lcio;
@@ -306,7 +306,6 @@ namespace overlay {
 
     std::mt19937 urng( Global::EVENTSEEDER->getSeed(this)  );
     std::shuffle(permutation->begin(), permutation->end(), urng );
-//    random_shuffle(permutation->begin(), permutation->end(), [](int n){ return CLHEP::RandFlat::shootInt(n); } );
 
     int random_file = CLHEP::RandFlat::shootInt(_inputFileNames.size());
 

--- a/src/OverlayTiming.cc
+++ b/src/OverlayTiming.cc
@@ -18,6 +18,7 @@
 #include <marlin/Global.h>
 #include <marlin/ProcessorEventSeeder.h>
 
+#include <random>
 #include <algorithm>
 #include <limits>
 #include <set>
@@ -303,7 +304,10 @@ namespace overlay {
         permutation->push_back(i);
       }
 
-    random_shuffle(permutation->begin(), permutation->end(), [](int n){ return CLHEP::RandFlat::shootInt(n); } );
+    std::random_device rng;
+    std::mt19937 urng(rng());
+    std::shuffle(permutation->begin(), permutation->end(), urng );
+//    random_shuffle(permutation->begin(), permutation->end(), [](int n){ return CLHEP::RandFlat::shootInt(n); } );
 
     int random_file = CLHEP::RandFlat::shootInt(_inputFileNames.size());
 

--- a/src/OverlayTiming.cc
+++ b/src/OverlayTiming.cc
@@ -304,8 +304,7 @@ namespace overlay {
         permutation->push_back(i);
       }
 
-    std::random_device rng;
-    std::mt19937 urng(rng());
+    std::mt19937 urng( Global::EVENTSEEDER->getSeed(this)  );
     std::shuffle(permutation->begin(), permutation->end(), urng );
 //    random_shuffle(permutation->begin(), permutation->end(), [](int n){ return CLHEP::RandFlat::shootInt(n); } );
 


### PR DESCRIPTION

BEGINRELEASENOTES
- make compatible w/ c++17
    - replace std::random_shuffle w/ std::shuffle in OverlayTiming
    - use std::mt19937 rather than CLHEP::RandFlat
ENDRELEASENOTES