### PR TITLE
Add workflow that runs coverity scan daily

### DIFF
--- a/.github/workflows/coverity.yml
+++ b/.github/workflows/coverity.yml
@@ -1,0 +1,21 @@
+name: coverity
+
+on:
+  schedule:
+    - cron: '0 0 * * *'
+
+jobs:
+  run-coverity:
+    runs-on: ubuntu-latest
+    if: github.repository == 'iLCSoft/Overlay'
+    steps:
+    - uses: actions/checkout@v2
+    - uses: cvmfs-contrib/cvmfs-github-action@v2
+    - uses: aidasoft/run-lcg-view@v3
+      with:
+        coverity-cmake-command: 'cmake -C $ILCSoft/ILCSoft.cmake ..'
+        coverity-project: 'iLCSoft%2FOverlay'
+        coverity-project-token: ${{ secrets.OVERLAY_COVERITY_TOKEN }}
+        github-pat: ${{ secrets.READ_COVERITY_IMAGE }}
+        view-path: "/cvmfs/clicdp.cern.ch/iLCSoft/lcg/97/nightly/x86_64-centos7-gcc9-opt"
+        setup-script: "init_ilcsoft.sh"

--- a/README.md
+++ b/README.md
@@ -1,5 +1,6 @@
 # Overlay
 [![Build](https://github.com/iLCSoft/Overlay/actions/workflows/linux.yml/badge.svg)](https://github.com/iLCSoft/Overlay/actions/workflows/linux.yml)
+[![coverity](https://scan.coverity.com/projects/11936/badge.svg)](https://scan.coverity.com/projects/ilcsoft-overlay)
 
 The package Overlay provides code for event overlay with Marlin
 


### PR DESCRIPTION
BEGINRELEASENOTES
- Add coverity scan workflow that runs daily

ENDRELEASENOTES

NOTE: Need to merge this so that the workflow can be picked up for testing.