### PR TITLE
Make starting integration time a configurable property.

### DIFF
--- a/include/OverlayTiming.h
+++ b/include/OverlayTiming.h
@@ -122,6 +122,7 @@ namespace overlay {
     float _OTE_int = 10;
     float _TPC_int = 10;
     float _TPCSpacePoint_int = 10;
+    float _DefaultStart_int = -0.25;
 
     IO::LCReader* overlay_Eventfile_reader = NULL;
     LCEvent* overlay_Evt = nullptr;

--- a/include/OverlayTiming.h
+++ b/include/OverlayTiming.h
@@ -122,6 +122,9 @@ namespace overlay {
     float _OTE_int = 10;
     float _TPC_int = 10;
     float _TPCSpacePoint_int = 10;
+
+    // The value of -0.25 is an arbitrary number for the moment but should be sufficient -- corresponds to 7.5cm of flight at c
+    // But if vertex smearing is on, this may need to be shifted earlier.
     float _DefaultStart_int = -0.25;
 
     IO::LCReader* overlay_Eventfile_reader = NULL;

--- a/src/OverlayTiming.cc
+++ b/src/OverlayTiming.cc
@@ -237,6 +237,11 @@ namespace overlay {
 			       _OTE_int,
 			       float(10));
 
+    registerProcessorParameter("Start_Integration_Time",
+                               "Starting integration time.  Should be shortly before the BX, but may need to be shifted earlier if the vertex is smeared in time.",
+                               _DefaultStart_int,
+                               float(-0.25));
+
     registerProcessorParameter("AllowReusingBackgroundFiles",
                                "If true the same background file can be used for the same event",
                                m_allowReusingBackgroundFiles,
@@ -545,8 +550,9 @@ namespace overlay {
 
   void OverlayTiming::define_time_windows(const std::string &Collection_name)
   {
-    this_start = -0.25; //the integration time shall start shortly before the BX with the physics event to avoid timing problems
-                        //the value of -0.25 is a arbitrary number for the moment but should be sufficient -- corresponds to 7.5cm of flight at c
+    this_start = _DefaultStart_int; //the integration time shall start shortly before the BX with the physics event to avoid timing problems
+                        //the value of -0.25 is an arbitrary number for the moment but should be sufficient -- corresponds to 7.5cm of flight at c
+                        //But if vertex smearing is on, this may need to be shifted earlier.
 
     this_stop = std::numeric_limits<float>::max(); // provide default values for collections not named below;
     TPC_hits = false;

--- a/src/OverlayTiming.cc
+++ b/src/OverlayTiming.cc
@@ -550,9 +550,7 @@ namespace overlay {
 
   void OverlayTiming::define_time_windows(const std::string &Collection_name)
   {
-    this_start = _DefaultStart_int; //the integration time shall start shortly before the BX with the physics event to avoid timing problems
-                        //the value of -0.25 is an arbitrary number for the moment but should be sufficient -- corresponds to 7.5cm of flight at c
-                        //But if vertex smearing is on, this may need to be shifted earlier.
+    this_start = _DefaultStart_int;
 
     this_stop = std::numeric_limits<float>::max(); // provide default values for collections not named below;
     TPC_hits = false;

--- a/src/OverlayTimingGeneric.cc
+++ b/src/OverlayTimingGeneric.cc
@@ -86,6 +86,10 @@ OverlayTimingGeneric::OverlayTimingGeneric(): OverlayTiming("OverlayTimingGeneri
 			       m_startWithBackgroundEvent,
 			       m_startWithBackgroundEvent);
 
+    registerProcessorParameter("Start_Integration_Time",
+                               "Starting integration time.  Should be shortly before the BX, but may need to be shifted earlier if the vertex is smeared in time.",
+                               _DefaultStart_int,
+                               float(-0.25));
 }
 
 void OverlayTimingGeneric::init()
@@ -125,7 +129,7 @@ void OverlayTimingGeneric::init()
 
 void OverlayTimingGeneric::define_time_windows( std::string const& collectionName ) {
 
-  this_start= -0.25; //the integration time shall start shortly before the BX
+  this_start= _DefaultStart_int; //the integration time shall start shortly before the BX
   //with the physics event to avoid timing problems the
   //value of -0.25 is a arbitrary number for the moment
   //but should be sufficient -- corresponds to 7.5cm of

--- a/src/OverlayTimingGeneric.cc
+++ b/src/OverlayTimingGeneric.cc
@@ -129,11 +129,7 @@ void OverlayTimingGeneric::init()
 
 void OverlayTimingGeneric::define_time_windows( std::string const& collectionName ) {
 
-  this_start= _DefaultStart_int; //the integration time shall start shortly before the BX
-  //with the physics event to avoid timing problems the
-  //value of -0.25 is a arbitrary number for the moment
-  //but should be sufficient -- corresponds to 7.5cm of
-  //flight at c
+  this_start= _DefaultStart_int;
 
   this_stop= 0.0;
   TPC_hits = false;


### PR DESCRIPTION
The starting integration time was hardcoded to -0.25ns.  Hits earlier than that time were removed.

However, if vertex smearing is enabled in time, then we may see legitimate hits earlier than that (for FCC, the smearing width is about 1.9 ns). Add a property to set this value, rather then hardcoding it.



BEGINRELEASENOTES
- OverlayTiming,OverlayTimingGeneric: Added property Start_Integration_Time to allow changing the starting integration time.  This defaults to the previously hardcoded value of -0.25, but may need to be moved earlier if vertex smearing is enabled.

ENDRELEASENOTES