### PR TITLE
Remove no longer available workflow based on gcc8

### DIFF
--- a/.github/workflows/linux.yml
+++ b/.github/workflows/linux.yml
@@ -9,14 +9,11 @@ jobs:
       matrix:
         COMPILER: [gcc10, clang11]
         LCG: [100]
-        include:
-          - COMPILER: gcc8
-            LCG: 99python2
 
     steps:
-    - uses: actions/checkout@v2
-    - uses: cvmfs-contrib/github-action-cvmfs@v2
-    - uses: aidasoft/run-lcg-view@v3
+    - uses: actions/checkout@v3
+    - uses: cvmfs-contrib/github-action-cvmfs@v3
+    - uses: aidasoft/run-lcg-view@v4
       with:
         view-path: "/cvmfs/clicdp.cern.ch/iLCSoft/lcg/${{ matrix.LCG }}/nightly/x86_64-centos7-${{ matrix.COMPILER }}-opt"
         setup-script: "init_ilcsoft.sh"


### PR DESCRIPTION
BEGINRELEASENOTES
- Remove no longer available gcc8 based workflow from CI
- Update github actions to latest available versions

ENDRELEASENOTES