### PR TITLE
OverlayTiming.cc: mark overlay particles as overlay

### DIFF
--- a/src/OverlayTiming.cc
+++ b/src/OverlayTiming.cc
@@ -716,6 +716,7 @@ namespace overlay {
                 if (((TrackerHit->getTime() + time_offset) > (this_start + _time_of_flight)) && ((TrackerHit->getTime() + time_offset) < (this_stop + _time_of_flight)))
 		  {
                     TrackerHit->setTime( TrackerHit->getTime() + time_offset);
+                    TrackerHit->setOverlay(true);
                     dest_collection->addElement(TrackerHit);
                     source_collection->removeElementAt(k);
 		  }
@@ -741,6 +742,7 @@ namespace overlay {
                         ort[2] = TrackerHit->getPosition()[2] + time_offset * _tpcVdrift_mm_ns;
 		      }
                     TrackerHit->setPosition(ort);
+                    TrackerHit->setOverlay(true);
                     dest_collection->addElement(TrackerHit);
                     source_collection->removeElementAt(k);
 		  }

--- a/src/OverlayTiming.cc
+++ b/src/OverlayTiming.cc
@@ -701,6 +701,7 @@ namespace overlay {
 	      {
                 MCParticleImpl *MC_Part = static_cast<MCParticleImpl*>(source_collection->getElementAt(i));
                 MC_Part->setTime(MC_Part->getTime() + time_offset);
+                MC_Part->setOverlay(true);
                 dest_collection->addElement(MC_Part);
                 source_collection->removeElementAt(i);
 	      }


### PR DESCRIPTION
The other Overlay processor does this correctly by using the merger for the merging, someone should probably refactor this one to also use that at some point?

I tested this change and it successfully adds the overlay flag to (only) the overlaid particles.

BEGINRELEASENOTES
- OverlayTiming.cc: mark overlay particles as overlay
- OverlayTiming.cc: mark overlay SimTrackerHits as overlay

ENDRELEASENOTES